### PR TITLE
Aumenta espaçamento em ícones de redes sociais e reduz logo do github

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,7 +91,7 @@
       Listagem de mulheres disponíveis para palestrar em eventos de tecnologia, design, empreendedorismo, entre outros.
     </p>
     <p><a href="http://insideoutproject.xyz/mulheres-palestrantes">Visite o projeto</a></p>
-    <p><i class="fa fa-github fa-2x"></i><a href="https://github.com/insideoutprojectbr/mulheres-palestrantes">Contribua aqui</a></p>
+    <p><span class="badge"><i class="fa fa-github"></i></span><a href="https://github.com/insideoutprojectbr/mulheres-palestrantes">Contribua aqui</a></p>
   </article>
   <a class="down" href="#rails-girls" data-scroll="" role=˜button˜>
         <svg class="icon icon-angle-down">

--- a/style/style.css
+++ b/style/style.css
@@ -69,14 +69,21 @@ header, article {
 }
 
 .badge {
- height: 0.5rem;
- padding-top: 0.25rem;
- padding-bottom: 0.25rem;
- padding-left: 0.65rem;
- padding-right: 0.65rem;
- width: 0.5rem;
- border-radius: 100%;
- background-color: #4e69a2;
+  margin-right: 0.5rem;
+}
+
+.fa.fa-github {
+  font-size: 2rem;
+  vertical-align: middle;
+  margin-bottom: 0.2rem;
+}
+
+.fa-facebook {
+  height: 2rem;
+  width: 2rem;
+  padding-top: 0.45rem;
+  border-radius: 100%;
+  background-color: #4e69a2;
 }
 
 #mulheres-palestrantes .title {


### PR DESCRIPTION
Os ícones do facebook e do github estão colados no link.
Além disso, o ícone do github parecia muito maior do que o do facebook e desalinhado.
