### PR TITLE
Não altera url ao clicar na seta de scroll

### DIFF
--- a/index.html
+++ b/index.html
@@ -184,7 +184,7 @@
 </section>
 <script src="js/smooth-scroll.js" charset="utf-8"></script>
 <script>
-    smoothScroll.init();
+    smoothScroll.init({ updateURL: false });
 </script>
 </body>
 </html>


### PR DESCRIPTION
Ao clicar na seta de scroll a url é alterada, porém ao continuar scrollando a url não é atualizada, tornando o comportamento estranho.
Removi a opção de atualizar a url pois a princípio não vejo muita necessidade para essa página.
